### PR TITLE
Tidy up the Terraform for our existing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ It includes the code for redirecting users from the old site to the appropriate 
 
 [opac]: https://en.wikipedia.org/wiki/Online_public_access_catalog
 
+## How it works
+
+*   There are CloudFront distributions for the wellcomelibrary.org domains in the platform account.
+
+*   The CloudFront distributions connected to Lambda@Edge function s(defined in edge-lambda), which decides where to redirect the user.
+
+    (We use Lambda@Edge instead of CloudFront Functions because we sometimes need to make HTTP requests before doing a redirect. e.g. looking up a b number from a URL so we can find the appropriate works page. Also, this work was started several years before CloudFront Functions were released.)
+
+*   The Route 53 hosted zone for wellcomelibrary.org is defined in a D&T account. We create DNS records in that hosted zone that point to our CloudFront distributions.
+
+*   We have staging and prod variants of each subdomain.
+    This allows us to test redirections before we put them live.
+
 ## How to
 
 *   [Add a static redirect to wellcomelibrary.org](docs/add-static-redirect.md)

--- a/terraform/cf_behaviours.tf
+++ b/terraform/cf_behaviours.tf
@@ -16,11 +16,6 @@ locals {
     }
   ]
 
-  prod_behaviours = concat(
-    local.moh_behaviours,
-  )
-
-  stage_behaviours = concat(
-    local.moh_behaviours,
-  )
+  prod_behaviours  = local.moh_behaviours
+  stage_behaviours = local.moh_behaviours
 }

--- a/terraform/cf_origins.tf
+++ b/terraform/cf_origins.tf
@@ -1,16 +1,16 @@
 locals {
   wellcome_library_origin = {
-    origin_id : "origin"
-    domain_name : "origin.wellcomelibrary.org"
-    origin_path : null
-    origin_protocol_policy : "match-viewer"
+    origin_id              = "origin"
+    domain_name            = "origin.wellcomelibrary.org"
+    origin_path            = null
+    origin_protocol_policy = "match-viewer"
   }
 
   wellcome_library_moh_origin = {
-    origin_id : "moh_origin"
-    domain_name : "moh.wellcomecollection.digirati.io"
-    origin_path : null
-    origin_protocol_policy : "match-viewer"
+    origin_id              = "moh_origin"
+    domain_name            = "moh.wellcomecollection.digirati.io"
+    origin_path            = null
+    origin_protocol_policy = "match-viewer"
   }
 
   prod_origins = [

--- a/terraform/distro_blog.wellcomelibrary.org.tf
+++ b/terraform/distro_blog.wellcomelibrary.org.tf
@@ -44,8 +44,6 @@ resource "aws_route53_record" "blog-prod" {
   zone_id = data.aws_route53_zone.zone.id
   name    = "blog.wellcomelibrary.org"
   type    = "CNAME"
-  // This is the previous on-premise address, if required for easy roll-back
-  //records = ["bloglibrary.wpengine.com"]
   records = [module.wellcomelibrary_blog-prod.distro_domain_name]
   ttl     = "60"
 

--- a/terraform/distro_blog.wellcomelibrary.org.tf
+++ b/terraform/distro_blog.wellcomelibrary.org.tf
@@ -1,61 +1,17 @@
-module "wellcomelibrary_blog-prod" {
-  source = "./modules/cloudfront_distro"
+module "wellcomelibrary_blog_redirects" {
+  source = "./modules/cloudfront_redirects"
 
-  distro_alternative_names = [
-    "blog.wellcomelibrary.org"
-  ]
+  prod_domain_name   = "blog.wellcomelibrary.org"
+  stage_domain_name  = "blog.stage.wellcomelibrary.org"
+  origin_domain_name = "origin.wellcomelibrary.org"
+
+  prod_redirect_function_arn  = local.wellcome_library_blog_redirect_arn_prod
+  stage_redirect_function_arn = local.wellcome_library_blog_redirect_arn_stage
+
   acm_certificate_arn = module.cert-stage.arn
+  route53_zone_id     = data.aws_route53_zone.zone.id
 
-  origins = [{
-    origin_id : "origin"
-    domain_name : "origin.wellcomelibrary.org"
-    origin_path : null
-    origin_protocol_policy : "match-viewer"
-  }]
-
-  default_target_origin_id                       = "origin"
-  default_lambda_function_association_event_type = "origin-request"
-  default_lambda_function_association_lambda_arn = local.wellcome_library_blog_redirect_arn_prod
-  default_forwarded_headers                      = ["Host"]
-}
-
-module "wellcomelibrary_blog-stage" {
-  source = "./modules/cloudfront_distro"
-
-  distro_alternative_names = [
-    "blog.stage.wellcomelibrary.org"
-  ]
-  acm_certificate_arn = module.cert-stage.arn
-
-  origins = [{
-    origin_id : "origin"
-    domain_name : "origin.wellcomelibrary.org"
-    origin_path : null
-    origin_protocol_policy : "match-viewer"
-  }]
-
-  default_target_origin_id                       = "origin"
-  default_lambda_function_association_event_type = "origin-request"
-  default_lambda_function_association_lambda_arn = local.wellcome_library_blog_redirect_arn_stage
-  default_forwarded_headers                      = ["Host"]
-}
-
-resource "aws_route53_record" "blog-prod" {
-  zone_id = data.aws_route53_zone.zone.id
-  name    = "blog.wellcomelibrary.org"
-  type    = "CNAME"
-  records = [module.wellcomelibrary_blog-prod.distro_domain_name]
-  ttl     = "60"
-
-  provider = aws.dns
-}
-
-resource "aws_route53_record" "blog-stage" {
-  zone_id = data.aws_route53_zone.zone.id
-  name    = "blog.stage.wellcomelibrary.org"
-  type    = "CNAME"
-  records = [module.wellcomelibrary_blog-stage.distro_domain_name]
-  ttl     = "60"
-
-  provider = aws.dns
+  providers = {
+    aws.dns = aws.dns
+  }
 }

--- a/terraform/distro_blog.wellcomelibrary.org.tf
+++ b/terraform/distro_blog.wellcomelibrary.org.tf
@@ -1,8 +1,8 @@
 module "wellcomelibrary_blog_redirects" {
   source = "./modules/cloudfront_redirects"
 
-  prod_domain_name   = "blog.wellcomelibrary.org"
-  stage_domain_name  = "blog.stage.wellcomelibrary.org"
+  prod_domain_name  = "blog.wellcomelibrary.org"
+  stage_domain_name = "blog.stage.wellcomelibrary.org"
 
   prod_redirect_function_arn  = local.wellcome_library_blog_redirect_arn_prod
   stage_redirect_function_arn = local.wellcome_library_blog_redirect_arn_stage

--- a/terraform/distro_blog.wellcomelibrary.org.tf
+++ b/terraform/distro_blog.wellcomelibrary.org.tf
@@ -3,7 +3,6 @@ module "wellcomelibrary_blog_redirects" {
 
   prod_domain_name   = "blog.wellcomelibrary.org"
   stage_domain_name  = "blog.stage.wellcomelibrary.org"
-  origin_domain_name = "origin.wellcomelibrary.org"
 
   prod_redirect_function_arn  = local.wellcome_library_blog_redirect_arn_prod
   stage_redirect_function_arn = local.wellcome_library_blog_redirect_arn_stage

--- a/terraform/distro_catalogue.wellcomelibrary.org.tf
+++ b/terraform/distro_catalogue.wellcomelibrary.org.tf
@@ -1,52 +1,42 @@
 // OPAC links (catalogue.wellcomelibrary.org)
 
-//module "wellcomelibrary_opac-prod" {
-//  source = "./modules/cloudfront_distro"
-//
-//  distro_alternative_names = [
-//    "catalogue.wellcomelibrary.org"
-//  ]
-//  acm_certificate_arn = module.cert-stage.arn
-//
-//  origins = [{
-//    origin_id : "origin"
-//    domain_name : "catalogue.origin.wellcomelibrary.org"
-//    origin_path : null
-//  }]
-//
-//  default_target_origin_id                       = "origin"
-//  default_lambda_function_association_event_type = "origin-request"
-//  default_lambda_function_association_lambda_arn = local.wellcome_library_passthru_arn_prod
-//  default_forwarded_headers                      = ["Host"]
-//}
-//
-module "wellcomelibrary_opac-stage" {
-  source = "./modules/cloudfront_distro"
-
-  distro_alternative_names = [
-    "catalogue.stage.wellcomelibrary.org"
-  ]
-  acm_certificate_arn = module.cert-stage.arn
-
-  origins = [{
-    origin_id : "origin"
-    domain_name : "catalogue.origin.wellcomelibrary.org"
-    origin_path : null
-    origin_protocol_policy : "match-viewer"
-  }]
-
-  default_target_origin_id                       = "origin"
-  default_lambda_function_association_event_type = "origin-request"
-  default_lambda_function_association_lambda_arn = local.wellcome_library_passthru_arn_prod
-  default_forwarded_headers                      = ["Host"]
+locals {
+  # This is the IP address of OPAC before we started redirecting it.
+  # Although OPAC will eventually be decommissioned and this IP address
+  # will stop working, it's kept here for easy rollback if necessary.
+  opac_ip_address = "195.143.129.134"
 }
 
+module "wellcomelibrary_catalogue_redirects" {
+  source = "./modules/cloudfront_redirects"
+
+  # This isn't enabled yet; see
+  # https://github.com/wellcomecollection/platform/issues/5580
+  disable_prod_redirect = true
+
+  prod_domain_name   = "catalogue.wellcomelibrary.org"
+  stage_domain_name  = "catalogue.stage.wellcomelibrary.org"
+  origin_domain_name = "catalogue.origin.wellcomelibrary.org"
+
+  prod_redirect_function_arn  = local.wellcome_library_passthru_arn_prod
+  stage_redirect_function_arn = local.wellcome_library_passthru_arn_stage
+
+  acm_certificate_arn = module.cert-stage.arn
+  route53_zone_id     = data.aws_route53_zone.zone.id
+
+  providers = {
+    aws.dns = aws.dns
+  }
+}
+
+# This will have to be removed when we enable redirects in prod, or the
+# DNS record for the redirect will conflict with this one.
 resource "aws_route53_record" "opac-prod" {
   zone_id = data.aws_route53_zone.zone.id
   name    = "catalogue.wellcomelibrary.org"
   type    = "A"
 
-  records = ["195.143.129.134"]
+  records = [local.opac_ip_address]
   ttl     = "300"
 
   provider = aws.dns
@@ -57,17 +47,7 @@ resource "aws_route53_record" "opac-origin" {
   name    = "catalogue.origin.wellcomelibrary.org"
   type    = "A"
 
-  records = ["195.143.129.134"]
-  ttl     = "60"
-
-  provider = aws.dns
-}
-
-resource "aws_route53_record" "opac-stage" {
-  zone_id = data.aws_route53_zone.zone.id
-  name    = "catalogue.stage.wellcomelibrary.org"
-  type    = "CNAME"
-  records = [module.wellcomelibrary_opac-stage.distro_domain_name]
+  records = [local.opac_ip_address]
   ttl     = "60"
 
   provider = aws.dns

--- a/terraform/distro_search.wellcomelibrary.org.tf
+++ b/terraform/distro_search.wellcomelibrary.org.tf
@@ -7,73 +7,29 @@ locals {
   encore_ip_address = "35.176.25.168"
 }
 
-module "wellcomelibrary_encore-prod" {
-  source = "./modules/cloudfront_distro"
+module "wellcomelibrary_search_redirects" {
+  source = "./modules/cloudfront_redirects"
 
-  distro_alternative_names = [
-    "search.wellcomelibrary.org"
-  ]
-  acm_certificate_arn = module.cert.arn
+  prod_domain_name   = "search.wellcomelibrary.org"
+  stage_domain_name  = "search.stage.wellcomelibrary.org"
+  origin_domain_name = "search.origin.wellcomelibrary.org"
 
-  origins = [{
-    origin_id : "origin"
-    domain_name : "search.origin.wellcomelibrary.org"
-    origin_path : null
-    origin_protocol_policy : "match-viewer"
-  }]
+  prod_redirect_function_arn  = local.wellcome_library_encore_redirect_arn_prod
+  stage_redirect_function_arn = local.wellcome_library_encore_redirect_arn_stage
 
-  default_target_origin_id                       = "origin"
-  default_lambda_function_association_event_type = "origin-request"
-  default_lambda_function_association_lambda_arn = local.wellcome_library_encore_redirect_arn_stage
-  default_forwarded_headers                      = ["Host"]
-}
-
-module "wellcomelibrary_encore-stage" {
-  source = "./modules/cloudfront_distro"
-
-  distro_alternative_names = [
-    "search.stage.wellcomelibrary.org"
-  ]
   acm_certificate_arn = module.cert-stage.arn
+  route53_zone_id     = data.aws_route53_zone.zone.id
 
-  origins = [{
-    origin_id : "origin"
-    domain_name : "search.origin.wellcomelibrary.org"
-    origin_path : null
-    origin_protocol_policy : "http-only"
-  }]
-
-  default_target_origin_id                       = "origin"
-  default_lambda_function_association_event_type = "origin-request"
-  default_lambda_function_association_lambda_arn = local.wellcome_library_encore_redirect_arn_stage
-  default_forwarded_headers                      = ["Host"]
-}
-
-resource "aws_route53_record" "encore-prod" {
-  zone_id = data.aws_route53_zone.zone.id
-  name    = "search.wellcomelibrary.org"
-  type    = "CNAME"
-  records = [module.wellcomelibrary_encore-prod.distro_domain_name]
-  ttl     = "300"
-
-  provider = aws.dns
+  providers = {
+    aws.dns = aws.dns
+  }
 }
 
 resource "aws_route53_record" "encore-origin" {
   zone_id = data.aws_route53_zone.zone.id
   name    = "search.origin.wellcomelibrary.org"
   type    = "CNAME"
-  records = [module.wellcomelibrary_encore-prod.distro_domain_name]
-  ttl     = "60"
-
-  provider = aws.dns
-}
-
-resource "aws_route53_record" "encore-stage" {
-  zone_id = data.aws_route53_zone.zone.id
-  name    = "search.stage.wellcomelibrary.org"
-  type    = "CNAME"
-  records = [module.wellcomelibrary_encore-stage.distro_domain_name]
+  records = [module.wellcomelibrary_search_redirects.prod_distro_domain_name]
   ttl     = "60"
 
   provider = aws.dns

--- a/terraform/distro_search.wellcomelibrary.org.tf
+++ b/terraform/distro_search.wellcomelibrary.org.tf
@@ -29,7 +29,7 @@ resource "aws_route53_record" "encore-origin" {
   zone_id = data.aws_route53_zone.zone.id
   name    = "search.origin.wellcomelibrary.org"
   type    = "CNAME"
-  records = [module.wellcomelibrary_search_redirects.prod_distro_domain_name]
+  records = module.wellcomelibrary_search_redirects.prod_distro_domain_name
   ttl     = "60"
 
   provider = aws.dns

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -1,66 +1,22 @@
-resource "aws_lambda_function" "wellcome_library_passthru" {
-  provider = aws.us_east_1
-
-  function_name = "cf_edge_wellcome_library_passthru"
-  role          = aws_iam_role.edge_lambda_role.arn
-  runtime       = "nodejs16.x"
-  handler       = "wellcomeLibraryPassthru.requestHandler"
-  publish       = true
-
-  s3_bucket         = data.aws_s3_bucket_object.wellcome_library_redirect.bucket
-  s3_key            = data.aws_s3_bucket_object.wellcome_library_redirect.key
-  s3_object_version = data.aws_s3_bucket_object.wellcome_library_redirect.version_id
+locals {
+  redirect_functions = {
+    passthru         = "wellcomeLibraryPassthru"
+    archive_redirect = "wellcomeLibraryArchiveRedirect"
+    blog_redirect    = "wellcomeLibraryBlogRedirect"
+    encore_redirect  = "wellcomeLibraryEncoreRedirect"
+    redirect         = "wellcomeLibraryRedirect"
+  }
 }
 
-resource "aws_lambda_function" "wellcome_library_encore_redirect" {
+resource "aws_lambda_function" "redirects" {
+  for_each = local.redirect_functions
+
   provider = aws.us_east_1
 
-  function_name = "cf_edge_wellcome_library_encore_redirect"
+  function_name = "cf_edge_wellcome_library_${each.key}"
   role          = aws_iam_role.edge_lambda_role.arn
   runtime       = "nodejs16.x"
-  handler       = "wellcomeLibraryEncoreRedirect.requestHandler"
-  publish       = true
-
-  s3_bucket         = data.aws_s3_bucket_object.wellcome_library_redirect.bucket
-  s3_key            = data.aws_s3_bucket_object.wellcome_library_redirect.key
-  s3_object_version = data.aws_s3_bucket_object.wellcome_library_redirect.version_id
-}
-
-resource "aws_lambda_function" "wellcome_library_archive_redirect" {
-  provider = aws.us_east_1
-
-  function_name = "cf_edge_wellcome_library_archive_redirect"
-  role          = aws_iam_role.edge_lambda_role.arn
-  runtime       = "nodejs16.x"
-  handler       = "wellcomeLibraryArchiveRedirect.requestHandler"
-  publish       = true
-
-  s3_bucket         = data.aws_s3_bucket_object.wellcome_library_redirect.bucket
-  s3_key            = data.aws_s3_bucket_object.wellcome_library_redirect.key
-  s3_object_version = data.aws_s3_bucket_object.wellcome_library_redirect.version_id
-}
-
-resource "aws_lambda_function" "wellcome_library_blog_redirect" {
-  provider = aws.us_east_1
-
-  function_name = "cf_edge_wellcome_library_blog_redirect"
-  role          = aws_iam_role.edge_lambda_role.arn
-  runtime       = "nodejs16.x"
-  handler       = "wellcomeLibraryBlogRedirect.requestHandler"
-  publish       = true
-
-  s3_bucket         = data.aws_s3_bucket_object.wellcome_library_redirect.bucket
-  s3_key            = data.aws_s3_bucket_object.wellcome_library_redirect.key
-  s3_object_version = data.aws_s3_bucket_object.wellcome_library_redirect.version_id
-}
-
-resource "aws_lambda_function" "wellcome_library_redirect" {
-  provider = aws.us_east_1
-
-  function_name = "cf_edge_wellcome_library_redirect"
-  role          = aws_iam_role.edge_lambda_role.arn
-  runtime       = "nodejs16.x"
-  handler       = "wellcomeLibraryRedirect.requestHandler"
+  handler       = "${local.redirect_functions[each.key]}.requestHandler"
   publish       = true
 
   s3_bucket         = data.aws_s3_bucket_object.wellcome_library_redirect.bucket

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -19,12 +19,12 @@ resource "aws_lambda_function" "redirects" {
   handler       = "${local.redirect_functions[each.key]}.requestHandler"
   publish       = true
 
-  s3_bucket         = data.aws_s3_bucket_object.wellcome_library_redirect.bucket
-  s3_key            = data.aws_s3_bucket_object.wellcome_library_redirect.key
-  s3_object_version = data.aws_s3_bucket_object.wellcome_library_redirect.version_id
+  s3_bucket         = data.aws_s3_object.wellcome_library_redirect.bucket
+  s3_key            = data.aws_s3_object.wellcome_library_redirect.key
+  s3_object_version = data.aws_s3_object.wellcome_library_redirect.version_id
 }
 
-data "aws_s3_bucket_object" "wellcome_library_redirect" {
+data "aws_s3_object" "wellcome_library_redirect" {
   provider = aws.us_east_1
 
   bucket = local.edge_lambdas_bucket

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,26 +1,26 @@
 locals {
-  wellcome_library_redirect_arn           = aws_lambda_function.wellcome_library_redirect.arn
-  wellcome_library_redirect_stage_version = aws_lambda_function.wellcome_library_redirect.version
+  wellcome_library_redirect_arn           = aws_lambda_function.redirects["redirect"].arn
+  wellcome_library_redirect_stage_version = aws_lambda_function.redirects["redirect"].version
   wellcome_library_redirect_arn_stage     = "${local.wellcome_library_redirect_arn}:${local.wellcome_library_redirect_stage_version}"
   wellcome_library_redirect_arn_prod      = "${local.wellcome_library_redirect_arn}:${local.prod_lambda_function_versions["wellcomelibrary"]}"
 
-  wellcome_library_passthru_arn           = aws_lambda_function.wellcome_library_passthru.arn
-  wellcome_library_passthru_stage_version = aws_lambda_function.wellcome_library_passthru.version
+  wellcome_library_passthru_arn           = aws_lambda_function.redirects["passthru"].arn
+  wellcome_library_passthru_stage_version = aws_lambda_function.redirects["passthru"].version
   wellcome_library_passthru_arn_stage     = "${local.wellcome_library_passthru_arn}:${local.wellcome_library_passthru_stage_version}"
   wellcome_library_passthru_arn_prod      = "${local.wellcome_library_passthru_arn}:${local.prod_lambda_function_versions["passthru"]}"
 
-  wellcome_library_blog_arn                = aws_lambda_function.wellcome_library_blog_redirect.arn
-  wellcome_library_blog_stage_version      = aws_lambda_function.wellcome_library_blog_redirect.version
+  wellcome_library_blog_arn                = aws_lambda_function.redirects["blog_redirect"].arn
+  wellcome_library_blog_stage_version      = aws_lambda_function.redirects["blog_redirect"].version
   wellcome_library_blog_redirect_arn_stage = "${local.wellcome_library_blog_arn}:${local.wellcome_library_blog_stage_version}"
   wellcome_library_blog_redirect_arn_prod  = "${local.wellcome_library_blog_arn}:${local.prod_lambda_function_versions["blog"]}"
 
-  wellcome_library_archive_arn                = aws_lambda_function.wellcome_library_archive_redirect.arn
-  wellcome_library_archive_stage_version      = aws_lambda_function.wellcome_library_archive_redirect.version
+  wellcome_library_archive_arn                = aws_lambda_function.redirects["archive_redirect"].arn
+  wellcome_library_archive_stage_version      = aws_lambda_function.redirects["archive_redirect"].version
   wellcome_library_archive_redirect_arn_stage = "${local.wellcome_library_archive_arn}:${local.wellcome_library_archive_stage_version}"
   wellcome_library_archive_redirect_arn_prod  = "${local.wellcome_library_archive_arn}:${local.prod_lambda_function_versions["archive"]}"
 
-  wellcome_library_encore_arn                = aws_lambda_function.wellcome_library_encore_redirect.arn
-  wellcome_library_encore_stage_version      = aws_lambda_function.wellcome_library_encore_redirect.version
+  wellcome_library_encore_arn                = aws_lambda_function.redirects["encore_redirect"].arn
+  wellcome_library_encore_stage_version      = aws_lambda_function.redirects["encore_redirect"].version
   wellcome_library_encore_redirect_arn_stage = "${local.wellcome_library_encore_arn}:${local.wellcome_library_encore_stage_version}"
   wellcome_library_encore_redirect_arn_prod  = "${local.wellcome_library_encore_arn}:${local.prod_lambda_function_versions["encore"]}"
 

--- a/terraform/modules/cloudfront_redirects/main.tf
+++ b/terraform/modules/cloudfront_redirects/main.tf
@@ -1,0 +1,68 @@
+module "prod" {
+  source = "../cloudfront_distro"
+
+  distro_alternative_names = [
+    var.prod_domain_name
+  ]
+
+  acm_certificate_arn = var.acm_certificate_arn
+
+  origins = [
+    {
+      origin_id              = "origin"
+      domain_name            = var.origin_domain_name
+      origin_path            = null
+      origin_protocol_policy = "match-viewer"
+    }
+  ]
+
+  default_target_origin_id                       = "origin"
+  default_lambda_function_association_event_type = "origin-request"
+  default_lambda_function_association_lambda_arn = var.prod_redirect_function_arn
+  default_forwarded_headers                      = ["Host"]
+}
+
+module "stage" {
+  source = "../cloudfront_distro"
+
+  distro_alternative_names = [
+    var.stage_domain_name
+  ]
+
+  acm_certificate_arn = var.acm_certificate_arn
+
+  origins = [
+    {
+      origin_id              = "origin"
+      domain_name            = var.origin_domain_name
+      origin_path            = null
+      origin_protocol_policy = "match-viewer"
+    }
+  ]
+
+  default_target_origin_id                       = "origin"
+  default_lambda_function_association_event_type = "origin-request"
+  default_lambda_function_association_lambda_arn = var.stage_redirect_function_arn
+  default_forwarded_headers                      = ["Host"]
+}
+
+resource "aws_route53_record" "prod" {
+  zone_id = var.route53_zone_id
+  name    = var.prod_domain_name
+  type    = "CNAME"
+
+  records = [module.prod.distro_domain_name]
+  ttl     = "60"
+
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "stage" {
+  zone_id = var.route53_zone_id
+  name    = var.stage_domain_name
+  type    = "CNAME"
+  records = [module.stage.distro_domain_name]
+  ttl     = "60"
+
+  provider = aws.dns
+}

--- a/terraform/modules/cloudfront_redirects/main.tf
+++ b/terraform/modules/cloudfront_redirects/main.tf
@@ -1,16 +1,7 @@
-locals {
-  prod_distro_alternative_names = var.prod_domain_name == "" ? var.prod_domain_names : [
-    var.prod_domain_name
-  ]
-  stage_distro_alternative_names = var.stage_domain_name == "" ? var.stage_domain_names : [
-    var.stage_domain_name
-  ]
-}
-
 module "cloudfront_prod" {
   source = "../cloudfront_distro"
 
-  distro_alternative_names = local.prod_distro_alternative_names
+  distro_alternative_names = [var.prod_domain_name]
 
   acm_certificate_arn = var.acm_certificate_arn
 
@@ -32,7 +23,7 @@ module "cloudfront_prod" {
 module "cloudfront_stage" {
   source = "../cloudfront_distro"
 
-  distro_alternative_names = local.stage_distro_alternative_names
+  distro_alternative_names = [var.stage_domain_name]
 
   acm_certificate_arn = var.acm_certificate_arn
 
@@ -52,10 +43,8 @@ module "cloudfront_stage" {
 }
 
 resource "aws_route53_record" "prod" {
-  for_each = toset(local.prod_distro_alternative_names)
-
   zone_id = var.route53_zone_id
-  name    = each.key
+  name    = var.prod_domain_name
   type    = "CNAME"
 
   records = [module.cloudfront_prod.distro_domain_name]
@@ -65,10 +54,8 @@ resource "aws_route53_record" "prod" {
 }
 
 resource "aws_route53_record" "stage" {
-  for_each = toset(local.stage_distro_alternative_names)
-
   zone_id = var.route53_zone_id
-  name    = each.key
+  name    = var.stage_domain_name
   type    = "CNAME"
   records = [module.cloudfront_stage.distro_domain_name]
   ttl     = "60"

--- a/terraform/modules/cloudfront_redirects/main.tf
+++ b/terraform/modules/cloudfront_redirects/main.tf
@@ -1,9 +1,16 @@
-module "prod" {
-  source = "../cloudfront_distro"
-
-  distro_alternative_names = [
+locals {
+  prod_distro_alternative_names = var.prod_domain_name == "" ? var.prod_domain_names : [
     var.prod_domain_name
   ]
+  stage_distro_alternative_names = var.stage_domain_name == "" ? var.stage_domain_names : [
+    var.stage_domain_name
+  ]
+}
+
+module "cloudfront_prod" {
+  source = "../cloudfront_distro"
+
+  distro_alternative_names = local.prod_distro_alternative_names
 
   acm_certificate_arn = var.acm_certificate_arn
 
@@ -19,15 +26,13 @@ module "prod" {
   default_target_origin_id                       = "origin"
   default_lambda_function_association_event_type = "origin-request"
   default_lambda_function_association_lambda_arn = var.prod_redirect_function_arn
-  default_forwarded_headers                      = ["Host"]
+  default_forwarded_headers                      = ["Host", "CloudFront-Forwarded-Proto"]
 }
 
-module "stage" {
+module "cloudfront_stage" {
   source = "../cloudfront_distro"
 
-  distro_alternative_names = [
-    var.stage_domain_name
-  ]
+  distro_alternative_names = local.stage_distro_alternative_names
 
   acm_certificate_arn = var.acm_certificate_arn
 
@@ -43,25 +48,29 @@ module "stage" {
   default_target_origin_id                       = "origin"
   default_lambda_function_association_event_type = "origin-request"
   default_lambda_function_association_lambda_arn = var.stage_redirect_function_arn
-  default_forwarded_headers                      = ["Host"]
+  default_forwarded_headers                      = ["Host", "CloudFront-Forwarded-Proto"]
 }
 
 resource "aws_route53_record" "prod" {
+  for_each = toset(local.prod_distro_alternative_names)
+
   zone_id = var.route53_zone_id
-  name    = var.prod_domain_name
+  name    = each.key
   type    = "CNAME"
 
-  records = [module.prod.distro_domain_name]
+  records = [module.cloudfront_prod.distro_domain_name]
   ttl     = "60"
 
   provider = aws.dns
 }
 
 resource "aws_route53_record" "stage" {
+  for_each = toset(local.stage_distro_alternative_names)
+
   zone_id = var.route53_zone_id
-  name    = var.stage_domain_name
+  name    = each.key
   type    = "CNAME"
-  records = [module.stage.distro_domain_name]
+  records = [module.cloudfront_stage.distro_domain_name]
   ttl     = "60"
 
   provider = aws.dns

--- a/terraform/modules/cloudfront_redirects/main.tf
+++ b/terraform/modules/cloudfront_redirects/main.tf
@@ -1,6 +1,8 @@
 module "cloudfront_prod" {
   source = "../cloudfront_distro"
 
+  count = var.disable_prod_redirect ? 0 : 1
+
   distro_alternative_names = [var.prod_domain_name]
 
   acm_certificate_arn = var.acm_certificate_arn
@@ -43,11 +45,13 @@ module "cloudfront_stage" {
 }
 
 resource "aws_route53_record" "prod" {
+  count = var.disable_prod_redirect ? 0 : 1
+
   zone_id = var.route53_zone_id
   name    = var.prod_domain_name
   type    = "CNAME"
 
-  records = [module.cloudfront_prod.distro_domain_name]
+  records = module.cloudfront_prod.*.distro_domain_name
   ttl     = "60"
 
   provider = aws.dns
@@ -57,7 +61,7 @@ resource "aws_route53_record" "stage" {
   zone_id = var.route53_zone_id
   name    = var.stage_domain_name
   type    = "CNAME"
-  records = [module.cloudfront_stage.distro_domain_name]
+  records = module.cloudfront_stage.*.distro_domain_name
   ttl     = "60"
 
   provider = aws.dns

--- a/terraform/modules/cloudfront_redirects/outputs.tf
+++ b/terraform/modules/cloudfront_redirects/outputs.tf
@@ -1,3 +1,3 @@
 output "prod_distro_domain_name" {
-  value = module.cloudfront_prod.distro_domain_name
+  value = module.cloudfront_prod.*.distro_domain_name
 }

--- a/terraform/modules/cloudfront_redirects/outputs.tf
+++ b/terraform/modules/cloudfront_redirects/outputs.tf
@@ -1,0 +1,3 @@
+output "prod_distro_domain_name" {
+  value = module.cloudfront_prod.distro_domain_name
+}

--- a/terraform/modules/cloudfront_redirects/provider.tf
+++ b/terraform/modules/cloudfront_redirects/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+
+      configuration_aliases = [aws.dns]
+    }
+  }
+}

--- a/terraform/modules/cloudfront_redirects/variables.tf
+++ b/terraform/modules/cloudfront_redirects/variables.tf
@@ -1,3 +1,8 @@
+variable "disable_prod_redirect" {
+  type    = bool
+  default = false
+}
+
 variable "prod_domain_name" {
   type    = string
   default = ""

--- a/terraform/modules/cloudfront_redirects/variables.tf
+++ b/terraform/modules/cloudfront_redirects/variables.tf
@@ -1,9 +1,21 @@
 variable "prod_domain_name" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "stage_domain_name" {
-  type = string
+  type    = string
+  default = ""
+}
+
+variable "prod_domain_names" {
+  type    = list(string)
+  default = []
+}
+
+variable "stage_domain_names" {
+  type    = list(string)
+  default = []
 }
 
 variable "origin_domain_name" {

--- a/terraform/modules/cloudfront_redirects/variables.tf
+++ b/terraform/modules/cloudfront_redirects/variables.tf
@@ -1,0 +1,27 @@
+variable "prod_domain_name" {
+  type = string
+}
+
+variable "stage_domain_name" {
+  type = string
+}
+
+variable "origin_domain_name" {
+  type = string
+}
+
+variable "prod_redirect_function_arn" {
+  type = string
+}
+
+variable "stage_redirect_function_arn" {
+  type = string
+}
+
+variable "acm_certificate_arn" {
+  type = string
+}
+
+variable "route53_zone_id" {
+  type = string
+}

--- a/terraform/modules/cloudfront_redirects/variables.tf
+++ b/terraform/modules/cloudfront_redirects/variables.tf
@@ -7,7 +7,8 @@ variable "stage_domain_name" {
 }
 
 variable "origin_domain_name" {
-  type = string
+  type    = string
+  default = "origin.wellcomelibrary.org"
 }
 
 variable "prod_redirect_function_arn" {


### PR DESCRIPTION
Some preliminary work for https://github.com/wellcomecollection/platform/issues/5580

This creates another layer of modules and abstraction in the Terraform, reducing boilerplate code and making all the redirects more consistent (e.g. the TTL for the DNS records was at least two different values, now they're all the same).

It also makes it easier (see the catalogue.wl.org redirects) to set up the prod redirects but not turn them on; this will be a much simpler change to enable.

The `wellcomelibrary.org` redirects aren't in the new model because there's a bunch of edge cases for MOH stuff I didn't fancy touching, but eventually we should bring them into this approach also.