### PR TITLE
Capture all the existing DNS records for wellcomelibrary.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It also includes all the DNS records for the `wellcomelibrary.org` domain.
     </a>
 
 *   `catalogue.wellcomelibrary.org` was another web front-end for the library catalogue/Sierra, often referred to as the OPAC ([online public access catalogue][opac]) or WebPAC.
-    
+
     We redirect requests to the new website, but only for external users.
     OPAC has some staff-specific functionality that we want to retain, so staff can still use it with the on-site network or the GlobalProtect VPN.
 
@@ -63,6 +63,8 @@ It also includes all the DNS records for the `wellcomelibrary.org` domain.
 
 *   `wellcomelibrary.org/iiif` and other paths (e.g. `/service/alto`) were IIIF services, including a IIIF Image API and IIIF presentation API.
     These services are now served from `iiif.wc.org`, and we redirect any requests for the old URLs to the new URLs.
+
+*   `libsys.wellcomelibrary.org` is the domain for the Sierra API, which is used (among other things) to populate the collections search on wc.org, and power item requesting on wc.org.
 
 [opac]: https://en.wikipedia.org/wiki/Online_public_access_catalog
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 This is the CloudFront distribution for the old `wellcomelibrary.org` website.
 It includes the code for redirecting users from the old site to the appropriate `wellcomecollection.org` URL.
 
+It also includes all the DNS records for the `wellcomelibrary.org` domain.
+
 ## Key pieces
 
 *   The CloudFront distributions are in the platform account.

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -8,6 +8,9 @@ locals {
   # This is for consistency with the DNS records that we do manage, and to
   # give us a bit of a safety net -- if we inadvertently blat a DNS record
   # as part of our changes, we should be able to roll it back.
+  #
+  # We may be able to remove these records in consultation with LS&S, if
+  # we know the records are defunct.
 
   cname_records = {
    "www.wellcomelibrary.org" = "wellcomelibrary.org"

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,3 +1,25 @@
+locals {
+  cname_records = {
+   "www.wellcomelibrary.org" = "wellcomelibrary.org"
+
+   "stage.wellcomelibrary.org"     = module.wellcomelibrary-stage.distro_domain_name
+   "www.stage.wellcomelibrary.org" = module.wellcomelibrary-stage.distro_domain_name
+
+   "deposit.wellcomelibrary.org" = "wt-hamilton.wellcome.ac.uk."
+  }
+
+  a_records = {
+    "encore.wellcomelibrary.org"           = "35.176.25.168"
+    "libsys.wellcomelibrary.org"           = "195.143.129.134"
+    "localhost.wellcomelibrary.org"        = "127.0.0.1"
+    "origin.wellcomelibrary.org"           = "195.143.129.236"
+    "print.wellcomelibrary.org"            = "195.143.129.141"
+    "support.wellcomelibrary.org"          = "54.75.184.123"
+    "support02.wellcomelibrary.org"        = "34.251.227.203"
+    "wt-lon-sierrasso.wellcomelibrary.org" = "195.143.129.211"
+  }
+}
+
 resource "aws_route53_record" "prod-internal" {
   zone_id = data.aws_route53_zone.zone.id
   name    = "wellcomelibrary.org"
@@ -36,17 +58,21 @@ resource "aws_route53_record" "prod-cloudfront" {
   provider = aws.dns
 }
 
-locals {
-  cname_records = {
-   "www.wellcomelibrary.org" = "wellcomelibrary.org"
+resource "aws_route53_record" "alpha" {
+  zone_id = data.aws_route53_zone.zone.id
+  name    = "alpha.wellcomelibrary.org"
+  type    = "A"
 
-   "stage.wellcomelibrary.org"     = module.wellcomelibrary-stage.distro_domain_name
-   "www.stage.wellcomelibrary.org" = module.wellcomelibrary-stage.distro_domain_name
+  alias {
+    name                   = "s3-website-eu-west-1.amazonaws.com"
+    evaluate_target_health = true
+
+    # This is a fixed value for S3 websites, see
+    # https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints
+    zone_id = "Z1BKCTXD74EZPE"
   }
 
-  a_records = {
-    "origin.wellcomelibrary.org" = "195.143.129.236"
-  }
+  provider = aws.dns
 }
 
 resource "aws_route53_record" "cname" {

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -49,21 +49,6 @@ locals {
   }
 }
 
-moved {
-  from = aws_route53_record.www
-  to   = aws_route53_record.cname["www.wellcomelibrary.org"]
-}
-
-moved {
-  from = aws_route53_record.stage
-  to   = aws_route53_record.cname["stage.wellcomelibrary.org"]
-}
-
-moved {
-  from = aws_route53_record.stage-www
-  to   = aws_route53_record.cname["www.stage.wellcomelibrary.org"]
-}
-
 resource "aws_route53_record" "cname" {
   for_each = local.cname_records
 
@@ -74,11 +59,6 @@ resource "aws_route53_record" "cname" {
   ttl     = 60
 
   provider = aws.dns
-}
-
-moved {
-  from = aws_route53_record.origin
-  to   = aws_route53_record.a["origin.wellcomelibrary.org"]
 }
 
 resource "aws_route53_record" "a" {

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -36,11 +36,24 @@ resource "aws_route53_record" "prod-cloudfront" {
   provider = aws.dns
 }
 
-resource "aws_route53_record" "www" {
+locals {
+  cname_records = {
+   "www.wellcomelibrary.org" = "wellcomelibrary.org"
+  }
+}
+
+moved {
+  from = aws_route53_record.www
+  to   = aws_route53_record.cname["www.wellcomelibrary.org"]
+}
+
+resource "aws_route53_record" "cname" {
+  for_each = local.cname_records
+
   zone_id = data.aws_route53_zone.zone.id
-  name    = "www.wellcomelibrary.org"
+  name    = each.key
   type    = "CNAME"
-  records = ["wellcomelibrary.org"]
+  records = [each.value]
   ttl     = "60"
 
   provider = aws.dns

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -13,14 +13,14 @@ locals {
   # we know the records are defunct.
 
   cname_records = {
-   "www.wellcomelibrary.org" = "wellcomelibrary.org"
+    "www.wellcomelibrary.org" = "wellcomelibrary.org"
 
-   "stage.wellcomelibrary.org"     = module.wellcomelibrary-stage.distro_domain_name
-   "www.stage.wellcomelibrary.org" = module.wellcomelibrary-stage.distro_domain_name
+    "stage.wellcomelibrary.org"     = module.wellcomelibrary-stage.distro_domain_name
+    "www.stage.wellcomelibrary.org" = module.wellcomelibrary-stage.distro_domain_name
 
-   "deposit.wellcomelibrary.org" = "wt-hamilton.wellcome.ac.uk."
+    "deposit.wellcomelibrary.org" = "wt-hamilton.wellcome.ac.uk."
 
-   "styleguide.wellcomelibrary.org" = "weblb01-1646100330.eu-west-1.elb.amazonaws.com."
+    "styleguide.wellcomelibrary.org" = "weblb01-1646100330.eu-west-1.elb.amazonaws.com."
   }
 
   a_records = {

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,4 +1,14 @@
 locals {
+  # Most of this block is a collection of DNS records that were in-place
+  # before the platform team existed, most of which we don't actively manage.
+  #
+  # Many of these records may be defunct; we captured them in Terraform
+  # in August 2022 so we had *a* snapshot of what these DNS records look like.
+  #
+  # This is for consistency with the DNS records that we do manage, and to
+  # give us a bit of a safety net -- if we inadvertently blat a DNS record
+  # as part of our changes, we should be able to roll it back.
+
   cname_records = {
    "www.wellcomelibrary.org" = "wellcomelibrary.org"
 
@@ -6,6 +16,8 @@ locals {
    "www.stage.wellcomelibrary.org" = module.wellcomelibrary-stage.distro_domain_name
 
    "deposit.wellcomelibrary.org" = "wt-hamilton.wellcome.ac.uk."
+
+   "styleguide.wellcomelibrary.org" = "weblb01-1646100330.eu-west-1.elb.amazonaws.com."
   }
 
   a_records = {
@@ -17,6 +29,34 @@ locals {
     "support.wellcomelibrary.org"          = "54.75.184.123"
     "support02.wellcomelibrary.org"        = "34.251.227.203"
     "wt-lon-sierrasso.wellcomelibrary.org" = "195.143.129.211"
+  }
+
+  mx_records = {
+    "wellcomelibrary.org" = "0 wellcome-ac-uk.mail.protection.outlook.com"
+  }
+
+  ns_records = [
+    "ns-1875.awsdns-42.co.uk.",
+    "ns-574.awsdns-07.net.",
+    "ns-337.awsdns-42.com.",
+    "ns-1041.awsdns-02.org.",
+  ]
+
+  soa_records = {
+    "wellcomelibrary.org" = "ns-1875.awsdns-42.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"
+  }
+
+  spf_records = [
+    "v=spf1 include:spf.protection.outlook.com -all",
+    "_globalsign-domain-verification=_oCvlC-4KkZ2udpJVZJtGuh7fNyu3K_ctmFQ4PPTXb",
+    "_globalsign-domain-verification=vu-ONisR1AncBASgChXZgIHSOoEQ0VRpwPeTWE13XW",
+    "C5Gnoujowp06bvP0R9XFqRxveoG80XT2kEy58fJBkEU=",
+    "_globalsign-domain-verification=mAFp_6t1sYlUNXcKKfhI6wI-uF6BRFdqcaX1E-CQLv",
+  ]
+
+  txt_records = {
+    "@.wellcomelibrary.org"               = "y/k5s8yhrhyvygnz1mqeiqrr6y7yfydlkqx0ew26fgmijc2clcfzhahpm3sabpagex5+kosi5ihkczazqx1iba=="
+    "_pki-validation.wellcomelibrary.org" = "C6D9-B435-F4B2-F818-47AB-A4EB-E8E7-71D4"
   }
 }
 
@@ -95,6 +135,62 @@ resource "aws_route53_record" "a" {
   type    = "A"
   records = [each.value]
   ttl     = 60
+
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "txt" {
+  for_each = local.txt_records
+
+  zone_id = data.aws_route53_zone.zone.id
+  name    = each.key
+  type    = "TXT"
+  records = [each.value]
+  ttl     = 60
+
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "soa" {
+  for_each = local.soa_records
+
+  zone_id = data.aws_route53_zone.zone.id
+  name    = each.key
+  type    = "SOA"
+  records = [each.value]
+  ttl     = 900
+
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "mx" {
+  for_each = local.mx_records
+
+  zone_id = data.aws_route53_zone.zone.id
+  name    = each.key
+  type    = "MX"
+  records = [each.value]
+  ttl     = 300
+
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "ns" {
+  zone_id = data.aws_route53_zone.zone.id
+  name    = "wellcomelibrary.org"
+  type    = "NS"
+  records = local.ns_records
+  ttl     = 172800
+
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "spf" {
+  zone_id = data.aws_route53_zone.zone.id
+  name    = "wellcomelibrary.org"
+  type    = "TXT"
+  records = local.spf_records
+  ttl     = 300
 
   provider = aws.dns
 }


### PR DESCRIPTION
This patch doesn't change any DNS records for wellcomelibrary.org (except a few TTLs); it captures the current state of the Route 53 Hosted Zone. This is to provide an audit trail and a safety net.

When I set up the redirects from search.wl.org &rarr; wc.org, I inadvertently deleted a few records that were a pain to roll back. I'm about to do some similar DNS fiddling for the migration of Sierra from on-prem to hosted III infrastructure, and I want to have the safety net of a known good state.

I checked this by comparing the number of records in Route53 (using a short boto3 script) and in Terraform (`terraform show -json` and parsing the output), and ensuring they were the same.