### PR TITLE
Switch from temporary to permanent redirects

### DIFF
--- a/edge-lambda/src/redirectHelpers.ts
+++ b/edge-lambda/src/redirectHelpers.ts
@@ -35,7 +35,7 @@ export function createRedirect(url: URL) {
   const headers = { ...locationHeaders, ...corsHeaders };
 
   return {
-    status: '302',
+    status: '301',
     statusDescription: `Redirecting to ${url}`,
     headers: headers,
   } as CloudFrontResultResponse;

--- a/edge-lambda/src/tests/lookupRedirect.test.ts
+++ b/edge-lambda/src/tests/lookupRedirect.test.ts
@@ -18,11 +18,10 @@ test('returns a valid redirect', async () => {
         },
       ],
     },
-    status: '302',
+    status: '301',
     statusDescription: 'Redirecting to http://www.example.com/bar',
   } as CloudFrontResultResponse;
 
-  // Temporary redirect should be updated to permanent when redirections are stable
   expect(lookupResult).toStrictEqual(expectedRedirect);
 });
 
@@ -42,11 +41,10 @@ test('strips trailing slashes', async () => {
         },
       ],
     },
-    status: '302',
+    status: '301',
     statusDescription: 'Redirecting to http://www.example.com/bar',
   } as CloudFrontResultResponse;
 
-  // Temporary redirect should be updated to permanent when redirections are stable
   expect(lookupResult).toStrictEqual(expectedRedirect);
 });
 
@@ -56,6 +54,5 @@ test('returns undefined when no redirect available', async () => {
     '/baz'
   );
 
-  // Temporary redirect should be updated to permanent when redirections are stable
   expect(lookupResult).toBe(undefined);
 });

--- a/edge-lambda/src/tests/redirectHelpers.test.ts
+++ b/edge-lambda/src/tests/redirectHelpers.test.ts
@@ -7,8 +7,7 @@ test('returns a valid redirect', () => {
     new URL('https://www.example.com')
   );
 
-  // Temporary redirect should be updated to permanent when redirections are stable
-  expect(redirect.status).toEqual('302');
+  expect(redirect.status).toEqual('301');
   const headers = redirect.headers;
   expect(headers).toEqual({
     location: [

--- a/edge-lambda/src/tests/testHelpers.ts
+++ b/edge-lambda/src/tests/testHelpers.ts
@@ -15,7 +15,7 @@ export function expectedServerError(
 
 export function expectedRedirect(uri: string): CloudFrontResultResponse {
   return {
-    status: '302',
+    status: '301',
     statusDescription: `Redirecting to ${uri}`,
     headers: {
       location: [

--- a/edge-lambda/src/tests/wellcomeLibraryRedirect.test.ts
+++ b/edge-lambda/src/tests/wellcomeLibraryRedirect.test.ts
@@ -270,7 +270,7 @@ test('redirects unknown paths to wellcomecollection.org', async () => {
 
   const originRequest = await origin.requestHandler(request, {} as Context);
 
-  expect(originRequest.status).toStrictEqual('302');
+  expect(originRequest.status).toStrictEqual('301');
   expect(originRequest.headers).toStrictEqual({
     'access-control-allow-origin': [
       { key: 'Access-Control-Allow-Origin', value: '*' },


### PR DESCRIPTION
I think this means any Google juice for wellcomelibrary.org will move to wellcomecollection.org instead.