### PR TITLE
Add new alias for print.wellcomelibrary.org

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -31,7 +31,6 @@ locals {
     "encore.wellcomelibrary.org"           = "35.176.25.168"
     "localhost.wellcomelibrary.org"        = "127.0.0.1"
     "origin.wellcomelibrary.org"           = "195.143.129.236"
-    "print.wellcomelibrary.org"            = "195.143.129.141"
     "support.wellcomelibrary.org"          = "54.75.184.123"
     "support02.wellcomelibrary.org"        = "34.251.227.203"
     "wt-lon-sierrasso.wellcomelibrary.org" = "195.143.129.211"
@@ -118,6 +117,23 @@ resource "aws_route53_record" "alpha" {
     # This is a fixed value for S3 websites, see
     # https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints
     zone_id = "Z1BKCTXD74EZPE"
+  }
+
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "print" {
+  zone_id = data.aws_route53_zone.zone.id
+  name    = "print.wellcomelibrary.org"
+  type    = "A"
+
+  alias {
+    name                   = "wt-aws-lizard-alb-153923399.eu-west-1.elb.amazonaws.com"
+    evaluate_target_health = true
+
+    # This is a fixed value for ELBs websites, see
+    # https://docs.aws.amazon.com/general/latest/gr/elb.html
+    zone_id = "Z32O12XQLNTSW2"
   }
 
   provider = aws.dns


### PR DESCRIPTION
> [!Note] 
> This change has been applied.

## What does this change?

This change adds a new alias record for `print.wellcomelibrary.org` to replace that [added in error to another repository](https://github.com/wellcometrust/wellcome-dns-infra/pull/364/files#diff-8fca836ad71c0bc8730a1d6097a82806a516b12182fdc43bf610e7a380748375R102).

This required removing the existing `print` alias from state and then importing the new state after recreating the resource:

```
terraform state rm 'aws_route53_record.a["print.wellcomelibrary.org"]'
terraform import aws_route53_record.print Z78J6G8RSOLSZ_print.wellcomelibrary.org_A
```

## How to test

- [x] Run `terraform plan`, ensure there are no changes to apply.

## How can we measure success?

DNS state managed in one place, avoiding confusion.

## Have we considered potential risks?

This state must be managed in one place only, and needs to be removed from the `wellcomedns` repository to avoid a risk of unexpected updates in the future.

