### PR TITLE
Add Sectigo CNAME record for wellcomelibrary.org

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -25,13 +25,14 @@ locals {
     # Sectigo domain name validation records
     # Sent by Flavio V 29 October 2024
     "_7c0ad5539ffa30ea5ec245e2a0bafae8.wellcomelibrary.org" = "d8bee243be7bad3b187120d52975a807.7aad28fde9eebc5586ae99ca8ab05a6c.sectigo.com"
+    # Sent by Flavio V 27 October 2025
+    "_b454cb8d684ba147d6454f193f817b0c.wellcomelibrary.org" = "7621a5c71a9b6af099911bcfb318030.b0aeba595b8aa0730a2b21b4a8ccac95.sectigo.com"
   }
 
   a_records = {
     "encore.wellcomelibrary.org"           = "35.176.25.168"
     "localhost.wellcomelibrary.org"        = "127.0.0.1"
     "origin.wellcomelibrary.org"           = "195.143.129.236"
-    "print.wellcomelibrary.org"            = "195.143.129.141"
     "support.wellcomelibrary.org"          = "54.75.184.123"
     "support02.wellcomelibrary.org"        = "34.251.227.203"
     "wt-lon-sierrasso.wellcomelibrary.org" = "195.143.129.211"
@@ -66,6 +67,19 @@ locals {
     # This value was sent by Slack from Flavio V on 11 June 2024
     "_pki-validation.wellcomelibrary.org" = "4BC7-9858-1376-FF06-DA6A-241D-9F06-F452"
   }
+}
+
+resource "aws_route53_record" "print-wellcomelibrary-org" {
+  zone_id = data.aws_route53_zone.zone.id
+  name    = "print.wellcomelibrary.org"
+  type    = "A"
+  alias {
+    evaluate_target_health = true
+    name                   = "wt-aws-lizard-alb-153923399.eu-west-1.elb.amazonaws.com"
+    zone_id                = "Z32O12XQLNTSW2"
+  }
+
+  provider = aws.dns
 }
 
 resource "aws_route53_record" "prod-internal" {


### PR DESCRIPTION
> [!Note]
> This terraform change change is applied.

## What does this change?

Adds a DNS record as per [this task](https://wellcome.service-now.com/now/nav/ui/classic/params/target/sc_task.do%3Fsys_id%3D009700983be0ba50812e0d3a85e45a34). We also update a record for print.wellcomecollection.org to reconcile state for that record (see https://github.com/wellcometrust/wellcome-dns-infra/pull/364#issuecomment-3196061175).

## How to test

- [ ] Run the terraform, does the CNAME record get created?

## How can we measure success?

Happy NCW team with no red lights on their dashboard.

## Have we considered potential risks?

Minimal, we are adding a new CNAME record, not making any modifications.